### PR TITLE
Add font customization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
   <br>
     <img src="./assets/shoppy-x-ray.svg" alt="logo" width="200">
   <br>
-  Shopify Skeleton Theme
+  Artelier Shopify Theme
 </h1>
 
-A minimal, carefully structured Shopify theme designed to help you quickly get started. Designed with modularity, maintainability, and Shopify's best practices in mind.
+A minimalist art-focused Shopify theme inspired by [leahgardner.art](https://leahgardner.art/). It builds on Shopify's skeleton theme and includes a split-screen hero with category links, an art gallery grid, and customizable brand fonts.
 
 <p align="center">
   <a href="./LICENSE.md"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License"></a>
@@ -148,6 +148,10 @@ For CSS and JavaScript, we recommend using the [`{% stylesheet %}`](https://shop
 ### `critical.css`
 
 The Skeleton Theme explicitly separates essential CSS necessary for every page into a dedicated `critical.css` file.
+
+## Customizations
+
+This theme ships with an art gallery section and a split hero inspired by [leahgardner.art](https://leahgardner.art/). The primary and secondary fonts can be selected in the theme settings under **Typography**. Headings use the secondary font, while body text uses the primary font.
 
 ## Contributing
 

--- a/assets/critical.css
+++ b/assets/critical.css
@@ -111,7 +111,7 @@ p:last-child {
 h1, .h1 {
   font-size: clamp(2.5rem, 5vw, 3.75rem); /* Matches hero links */
   font-weight: 600;
-  font-family: var(--font-primary--family);
+  font-family: var(--font-secondary--family, var(--font-primary--family));
   line-height: 1.1;
   margin-bottom: 1.5rem;
   color: var(--color-accent); /* Default h1 to accent color */
@@ -120,7 +120,7 @@ h1, .h1 {
 h2, .h2 {
   font-size: clamp(1.75rem, 4vw, 2.5rem);
   font-weight: 500;
-  font-family: var(--font-primary--family);
+  font-family: var(--font-secondary--family, var(--font-primary--family));
   line-height: 1.2;
   margin-bottom: 1rem;
 }
@@ -128,6 +128,7 @@ h2, .h2 {
 h3, .h3 {
   font-size: clamp(1.25rem, 3vw, 1.75rem);
   font-weight: 500;
+  font-family: var(--font-secondary--family, var(--font-primary--family));
   line-height: 1.3;
   margin-bottom: 0.75rem;
 }

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -94,6 +94,8 @@
     "order": [
       "hero-categories",
       "gallery"
-    ]
+    ],
+    "type_primary_font": "work_sans_n4",
+    "type_secondary_font": "playfair_display_n4"
   }
 }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -20,6 +20,12 @@
         "default": "work_sans_n4",
         "label": "t:general.primary"
       },
+      {
+        "type": "font_picker",
+        "id": "type_secondary_font",
+        "default": "playfair_display_n4",
+        "label": "Secondary font"
+      }
     ]
   },
   {

--- a/snippets/css-variables.liquid
+++ b/snippets/css-variables.liquid
@@ -4,11 +4,15 @@
   {{ settings.type_primary_font | font_modify: 'weight', 'bold' | font_face: font_display: 'swap' }}
   {{ settings.type_primary_font | font_modify: 'weight', 'bold' | font_modify: 'style', 'italic' | font_face: font_display: 'swap' }}
   {{ settings.type_primary_font | font_modify: 'style', 'italic' | font_face: font_display: 'swap' }}
+  {{ settings.type_secondary_font | font_face: font_display: 'swap' }}
+  {{ settings.type_secondary_font | font_modify: 'weight', 'bold' | font_face: font_display: 'swap' }}
+  {{ settings.type_secondary_font | font_modify: 'style', 'italic' | font_face: font_display: 'swap' }}
 
   :root {
     --font-primary--family: {{ settings.type_primary_font.family }}, {{ settings.type_primary_font.fallback_families }};
     --font-primary--style: {{ settings.type_primary_font.style }};
     --font-primary--weight: {{ settings.type_primary_font.weight }};
+    --font-secondary--family: {{ settings.type_secondary_font.family }}, {{ settings.type_secondary_font.fallback_families }};
     --page-width: {{ settings.max_page_width }};
     --page-margin: {{ settings.min_page_margin }}px;
     --color-background: {{ settings.background_color }};


### PR DESCRIPTION
## Summary
- enable secondary font selection via theme settings
- expose secondary font CSS variables
- use secondary font for all headings
- document customizations and theme purpose

## Testing
- `bundle exec theme-check -C .theme-check.yml` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_684a77d2309c83338d3e1c8d29d30d19