### PR TITLE
Add zoom effect on image hover

### DIFF
--- a/assets/critical.css
+++ b/assets/critical.css
@@ -255,9 +255,17 @@ h3, .h3 {
 
 .visually-hidden {
   position: absolute !important;
-  height: 1px; 
+  height: 1px;
   width: 1px;
   overflow: hidden;
   clip: rect(1px, 1px, 1px, 1px);
   white-space: nowrap; /* For SRO text */
+}
+
+/* Zoom effect on image hover */
+img.zoom-hover {
+  transition: transform 0.3s ease;
+}
+img.zoom-hover:hover {
+  transform: scale(1.05);
 }

--- a/sections/art-gallery.liquid
+++ b/sections/art-gallery.liquid
@@ -23,7 +23,7 @@
                             {{ product.featured_image | image_url: width: 900 }} 900w"
                     sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, 33vw"
                     alt="{{ product.featured_image.alt | escape }}"
-                    class="gallery-image"
+                    class="gallery-image zoom-hover"
                     loading="lazy"
                     width="{{ product.featured_image.width }}"
                     height="{{ product.featured_image.height }}"
@@ -126,7 +126,7 @@
     }
     
     .gallery-item:hover .gallery-image {
-      /* transform: scale(1.05); /* Subtle zoom on hover */
+      transform: scale(1.05); /* Subtle zoom on hover */
     }
     
     .gallery-info {

--- a/sections/cart.liquid
+++ b/sections/cart.liquid
@@ -16,7 +16,7 @@
             <div class="cart-item-image">
               {% if item.image %}
                 <a href="{{ item.url | within: collections.all }}">
-                  <img src="{{ item.image | image_url: width: 200 }}" alt="{{ item.image.alt | escape }}" width="{{ item.image.width }}" height="{{ item.image.height }}">
+                  <img src="{{ item.image | image_url: width: 200 }}" alt="{{ item.image.alt | escape }}" class="zoom-hover" width="{{ item.image.width }}" height="{{ item.image.height }}">
                 </a>
               {% else %}
                 <div class="cart-item-placeholder"></div>

--- a/sections/collection.liquid
+++ b/sections/collection.liquid
@@ -23,7 +23,7 @@
               <div class="gallery-image-wrapper">
                 <img src="{{ product.featured_image | image_url: width: 600 }}"
                      alt="{{ product.featured_image.alt | escape }}"
-                     class="collection-product-image-art"
+                     class="collection-product-image-art zoom-hover"
                      width="{{ product.featured_image.width }}"
                      height="{{ product.featured_image.height }}">
               </div>

--- a/sections/hello-world.liquid
+++ b/sections/hello-world.liquid
@@ -18,7 +18,7 @@
       </p>
     </div>
     <div class="icon">
-      <img src="{{ 'shoppy-x-ray.svg' | asset_url }}" width="300" height="300">
+      <img src="{{ 'shoppy-x-ray.svg' | asset_url }}" class="zoom-hover" width="300" height="300">
     </div>
   </div>
 </div>

--- a/sections/hero-image.liquid
+++ b/sections/hero-image.liquid
@@ -14,7 +14,7 @@
                   {{ section.settings.hero_image | image_url: width: 1920 }} 1920w"
           sizes="100vw"
           alt="{{ section.settings.hero_image.alt | escape }}"
-          class="hero-image"
+          class="hero-image zoom-hover"
           loading="eager"
           width="{{ section.settings.hero_image.width }}"
           height="{{ section.settings.hero_image.height }}"

--- a/sections/hero-with-categories.liquid
+++ b/sections/hero-with-categories.liquid
@@ -26,7 +26,7 @@
           <img
             src="{{ block.settings.image | image_url: width: 1200 }}"
             alt="{{ block.settings.title }}"
-            class="hero-image-actual"
+            class="hero-image-actual zoom-hover"
             data-image-index="{{ forloop.index0 }}"
             style="{% if forloop.first %}display:block{% else %}display:none{% endif %}"
             width="{{ block.settings.image.width }}"

--- a/sections/product.liquid
+++ b/sections/product.liquid
@@ -11,7 +11,7 @@
     <div class="product-image-col-leah">
       {% if product.images.size > 0 %}
         {% for image in product.images %}
-          <img src="{{ image | image_url: width: 900 }}" alt="{{ product.title | escape }}" class="product-main-image-leah" width="{{ image.width }}" height="{{ image.height }}">
+          <img src="{{ image | image_url: width: 900 }}" alt="{{ product.title | escape }}" class="product-main-image-leah zoom-hover" width="{{ image.width }}" height="{{ image.height }}">
         {% endfor %}
       {% else %}
         <div class="product-image-placeholder-leah"></div>

--- a/sections/search.liquid
+++ b/sections/search.liquid
@@ -35,7 +35,7 @@
             <a href="{{ result.url }}" class="search-result-item">
               {% assign featured_image = result.featured_image | default: result.image %}
               {% if featured_image %}
-                <img src="{{ featured_image | image_url: width: 400 }}" alt="{{ result.title | escape }}" class="search-result-image" width="{{ featured_image.width }}" height="{{ featured_image.height }}">
+                <img src="{{ featured_image | image_url: width: 400 }}" alt="{{ result.title | escape }}" class="search-result-image zoom-hover" width="{{ featured_image.width }}" height="{{ featured_image.height }}">
               {% endif %}
               <div class="search-result-content">
                 <h2 class="search-result-title">{{ result.title }}</h2>


### PR DESCRIPTION
## Summary
- add a `zoom-hover` CSS helper to create a slight zoom on image hover
- apply the helper to images across gallery, collection, product and more sections
- enable existing gallery zoom style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ae31a326083338ff1fefd10f96f60