### PR TITLE
Add hero categories with subcategories

### DIFF
--- a/assets/critical.css
+++ b/assets/critical.css
@@ -24,8 +24,8 @@ body {
   flex-direction: column;
   min-height: 100vh; /* Changed from svh for broader compatibility */
   font-family: var(--font-primary--family, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
-  background-color: var(--color-background, #ffffff);
-  color: var(--color-foreground, #2c2c2c);
+  background-color: var(--color-background, #E6BDBE);
+  color: var(--color-foreground, #000000);
   line-height: 1.6; /* Specific body line-height */
 }
 
@@ -67,8 +67,8 @@ p:last-child {
 
 /* Art Theme Specific Styles */
 :root {
-  --color-background: #ffffff;
-  --color-foreground: #222222; /* Slightly darker foreground */
+  --color-background: #E6BDBE;
+  --color-foreground: #000000; /* Slightly darker foreground */
   --color-accent: #1e1e1e; /* Main accent color changed to dark gray */
   --color-accent-secondary: #fce5d8; /* Light pink for title like leahgardner.art */
   --color-muted: #555555; /* Darker muted color */

--- a/assets/critical.css
+++ b/assets/critical.css
@@ -23,10 +23,17 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh; /* Changed from svh for broader compatibility */
-  font-family: var(--font-primary--family, 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  font-family: var(--font-primary--family, martianmono, sans-serif);
+  font-size: 12px;
+  line-height: 20px;
+  -webkit-font-kerning: normal;
+  font-kerning: normal;
+  text-rendering: optimizeLegibility;
+  -webkit-font-feature-settings: "onum" 1;
+  font-feature-settings: "onum" 1;
   background-color: var(--color-background, #E6BDBE);
-  color: var(--color-foreground, #000000);
-  line-height: 1.6; /* Specific body line-height */
+  color: var(--black);
+  padding: 0;
 }
 
 /* Scroll lock for modals/dialogs */
@@ -75,8 +82,9 @@ p:last-child {
   --color-border: #dddddd; /* Lighter border */
   --color-card-bg: #f9f9f9;
   
-  --font-primary--family: 'Helvetica Neue', Helvetica, Arial, sans-serif; /* Common sans-serif */
-  --font-secondary--family: 'Helvetica Neue', Helvetica, Arial, sans-serif; /* Using same for simplicity, can be changed */
+  --font-primary--family: 'martianmono', sans-serif;
+  --font-secondary--family: 'ppright', sans-serif;
+  --black: #000000;
   --main-font-stack: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
   
   --page-width: 1400px; /* Max page width */
@@ -110,12 +118,15 @@ p:last-child {
 
 /* Typography Scale */
 h1, .h1 {
-  font-size: clamp(2.5rem, 5vw, 3.75rem); /* Matches hero links */
-  font-weight: 600;
-  font-family: var(--font-secondary--family, var(--font-primary--family));
-  line-height: 1.1;
+  font-family: var(--font-secondary--family, ppright, sans-serif);
+  font-weight: 400;
+  -webkit-font-feature-settings: "onum" 0, "case" 1;
+  font-feature-settings: "onum" 0, "case" 1;
+  text-transform: uppercase;
+  font-size: 55px;
+  line-height: 48px;
   margin-bottom: 1.5rem;
-  color: var(--color-accent); /* Default h1 to accent color */
+  color: var(--color-accent);
 }
 
 h2, .h2 {

--- a/assets/critical.css
+++ b/assets/critical.css
@@ -130,9 +130,12 @@ h1, .h1 {
 }
 
 h2, .h2 {
+  font-family: var(--font-secondary--family, ppright, sans-serif);
+  font-weight: 400;
+  -webkit-font-feature-settings: "onum" 0, "case" 1;
+  font-feature-settings: "onum" 0, "case" 1;
+  text-transform: uppercase;
   font-size: clamp(1.75rem, 4vw, 2.5rem);
-  font-weight: 500;
-  font-family: var(--font-secondary--family, var(--font-primary--family));
   line-height: 1.2;
   margin-bottom: 1rem;
 }
@@ -143,6 +146,18 @@ h3, .h3 {
   font-family: var(--font-secondary--family, var(--font-primary--family));
   line-height: 1.3;
   margin-bottom: 0.75rem;
+}
+
+a {
+  font-family: var(--font-primary--family, martianmono, sans-serif);
+  font-size: 12px;
+  line-height: 20px;
+  -webkit-font-kerning: normal;
+  font-kerning: normal;
+  text-rendering: optimizeLegibility;
+  -webkit-font-feature-settings: "onum" 1;
+  font-feature-settings: "onum" 1;
+  color: var(--black);
 }
 
 /* Section Layout Utilities */

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -19,6 +19,14 @@
       "hero-categories": {
         "type": "hero-with-categories",
         "blocks": {
+          "originals": {
+            "type": "category_link",
+            "settings": {
+              "title": "originals",
+              "link": "/collections/originals",
+              "subcategories": "Figurative Art\nLandscapes\nStill Life\nUrban Art & Cities\nAnimal Art\nSurrealist Art\nAbstract Art"
+            }
+          },
           "mixed-media": {
             "type": "category_link",
             "settings": {
@@ -26,55 +34,18 @@
               "link": "/collections/mixed-media"
             }
           },
-          "originals": {
+          "prints": {
             "type": "category_link",
             "settings": {
-              "title": "originals",
-              "link": "/collections/originals"
-            }
-          },
-          "exhibitions": {
-            "type": "category_link",
-            "settings": {
-              "title": "exhibitions",
-              "link": "/collections/exhibitions"
-            }
-          },
-          "wallpapers": {
-            "type": "category_link",
-            "settings": {
-              "title": "wallpapers",
-              "link": "/collections/wallpapers"
-            }
-          },
-          "merch": {
-            "type": "category_link",
-            "settings": {
-              "title": "merch",
-              "link": "/collections/merch"
-            }
-          },
-          "about": {
-            "type": "category_link",
-            "settings": {
-              "title": "about",
-              "link": "/pages/about"
-            }
-          },
-          "faq": {
-            "type": "category_link",
-            "settings": {
-              "title": "faq",
-              "link": "/pages/faq"
+              "title": "prints",
+              "link": "/collections/prints"
             }
           }
         },
         "block_order": [
           "originals",
           "mixed-media",
-          "exhibitions",
-          "about",
-          "faq"
+          "prints"
         ],
         "settings": {
           "hero_image": "shopify://shop_images/your-hero-image.jpg"

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -11,6 +11,8 @@
   "current": {
     "type_primary_font": "work_sans_n4",
     "type_secondary_font": "playfair_display_n4",
+    "background_color": "#E6BDBE",
+    "foreground_color": "#000000",
     "order": [
       "hero-categories",
       "gallery"

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -65,13 +65,13 @@
       {
         "type": "color",
         "id": "background_color",
-        "default": "#FFFFFF",
+        "default": "#E6BDBE",
         "label": "t:labels.background"
       },
       {
         "type": "color",
         "id": "foreground_color",
-        "default": "#333333",
+        "default": "#000000",
         "label": "t:labels.foreground"
       },
       {

--- a/sections/art-gallery.liquid
+++ b/sections/art-gallery.liquid
@@ -116,6 +116,7 @@
       position: relative;
       overflow: hidden;
       aspect-ratio: 1 / 1; /* Square images */
+      border-radius: 8px;
     }
     
     .gallery-image, .placeholder-svg {

--- a/sections/cart.liquid
+++ b/sections/cart.liquid
@@ -61,7 +61,7 @@
   max-width: 1200px;
   margin: 4rem auto;
   padding: 0 2rem;
-  font-family: var(--main-font-stack);
+  font-family: var(--font-primary--family, martianmono, sans-serif);
   color: var(--color-foreground);
 }
 

--- a/sections/collection.liquid
+++ b/sections/collection.liquid
@@ -196,11 +196,11 @@
   }
 }
 body, h1, h2, h3, h4, h5, h6 {
-  font-family: var(--main-font-stack);
+  font-family: var(--font-primary--family, martianmono, sans-serif);
 }
 
 .about-artist-section, .hero-categories-section, .gallery-title {
-  font-family: var(--font-primary--family, 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif);
+  font-family: var(--font-secondary--family, ppright, sans-serif);
 }
 
 .gallery-image-wrapper {

--- a/sections/collection.liquid
+++ b/sections/collection.liquid
@@ -93,9 +93,7 @@
 .collection-products-art {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0;
-  border-top: 1px solid #1e1e1e;
-  border-left: 1px solid #1e1e1e;
+  gap: 10px;
 }
 .collection-product-art {
   background: #fff;
@@ -107,8 +105,8 @@
   position: relative;
   transition: box-shadow 0.2s;
   break-inside: avoid;
-  border-right: 1px solid #1e1e1e;
-  border-bottom: 1px solid #1e1e1e;
+  border-right: none;
+  border-bottom: none;
 }
 
 .collection-product-link-art {
@@ -128,6 +126,7 @@
   justify-content: center;
   align-items: center;
   background: #f8f8f8;
+  border-radius: 8px;
   margin-bottom: 0;
 }
 .collection-product-image-art {
@@ -206,6 +205,7 @@ body, h1, h2, h3, h4, h5, h6 {
 .gallery-image-wrapper {
   overflow: hidden;
   /* Можно добавить фиксированную высоту/ширину, если нужно */
+  border-radius: 8px;
 }
 
 .gallery-image {

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -59,7 +59,7 @@
 .site-footer {
   font-family: var(--main-font-stack);
   color: var(--color-foreground);
-  background-color: #fff;
+  background-color: var(--color-background, #E6BDBE);
   box-sizing: border-box;
 }
 
@@ -93,11 +93,11 @@
 }
 
 .footer-nav-link {
-  color: #111;
+  color: var(--color-foreground, #000000);
   text-decoration: none;
   font-size: 1rem;
   transition: opacity 0.2s;
-}
+  }
 
 .footer-nav-link:hover {
   opacity: 0.7;
@@ -111,7 +111,7 @@
   justify-content: space-between;
   align-items: center;
   font-size: 0.9rem;
-  color: #111;
+  color: var(--color-foreground, #000000);
 }
 
 .footer-copyright-small {

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -57,7 +57,7 @@
 <style>
 /* Base Footer Styles */
 .site-footer {
-  font-family: var(--main-font-stack);
+  font-family: var(--font-primary--family, martianmono, sans-serif);
   color: var(--color-foreground);
   background-color: var(--color-background, #E6BDBE);
   box-sizing: border-box;

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -29,10 +29,10 @@
       </div>
       <div class="header-actions">
         <a href="/search" class="header-action-link header-search" aria-label="Search">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#1e1e1e" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-foreground, #000000)" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
         </a>
         <a href="{{ routes.cart_url }}" class="header-action-link header-cart" id="cart-icon-bubble">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#1e1e1e" stroke-width="1.5">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-foreground, #000000)" stroke-width="1.5">
             <circle cx="8" cy="21" r="1"/>
             <circle cx="19" cy="21" r="1"/>
             <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57L23 6H6"/>
@@ -55,7 +55,8 @@
     right: 0;
     z-index: 30;
     width: 100%;
-    background-color: white;
+    background-color: var(--color-background, #E6BDBE);
+    color: var(--color-foreground, #000000);
     padding: 0.75rem 2rem;
     transition: all 0.3s ease;
   }
@@ -172,7 +173,7 @@
     display: none;
     position: fixed;
     top: 0; left: 0; right: 0; bottom: 0;
-    background: #fff;
+    background: var(--color-background, #E6BDBE);
     z-index: 9999;
     flex-direction: column;
     width: 100vw;

--- a/sections/hero-with-categories.liquid
+++ b/sections/hero-with-categories.liquid
@@ -15,14 +15,6 @@
                 <a href="{{ block.settings.link }}" class="category-link-hero">
                   {{ block.settings.title | downcase }}
                 </a>
-                {% assign subs = block.settings.subcategories | newline_to_br | split: '<br />' %}
-                {% if subs.size > 0 and subs[0] != '' %}
-                  <ul class="subcategory-list-hero">
-                    {% for sub in subs %}
-                      <li class="subcategory-item-hero">{{ sub }}</li>
-                    {% endfor %}
-                  </ul>
-                {% endif %}
               </li>
             {% endfor %}
           </ul>
@@ -116,17 +108,6 @@
       width: 100%;
       box-sizing: border-box;
       border-bottom: 1px solid #1e1e1e; /* Bottom border for each item */
-    }
-    .subcategory-list-hero {
-      list-style: none;
-      margin: 0;
-      padding: 0 0 0 1.5rem;
-    }
-    .subcategory-item-hero {
-      font-size: clamp(1rem, 3vw, 1.5rem);
-      font-weight: 400;
-      line-height: 1.2;
-      padding: 0.25em 0;
     }
     .category-link-hero {
       display: block;

--- a/sections/hero-with-categories.liquid
+++ b/sections/hero-with-categories.liquid
@@ -60,7 +60,7 @@
       flex-direction: column;
       justify-content: flex-start; /* Vertically center links */
       padding: 2rem 3rem; /* Ample padding */
-      background-color: var(--color-background, #ffffff);
+      background-color: var(--color-background, #E6BDBE);
       position: relative;
       z-index: 2;
       box-sizing: border-box;
@@ -112,8 +112,12 @@
     .category-link-hero {
       display: block;
       font-size: clamp(2rem, 6vw, 4.75rem); /* Responsive font size */
-      font-weight: 600; /* Bold like screenshot */
-      color: #1e1e1e; /* Orange color from screenshot */
+      font-family: var(--font-secondary--family, ppright, sans-serif);
+      font-weight: 400;
+      -webkit-font-feature-settings: "onum" 0, "case" 1;
+      font-feature-settings: "onum" 0, "case" 1;
+      text-transform: uppercase;
+      color: var(--color-foreground, #000000);
       text-decoration: none;
       padding: 0.5em 1em; /* Adjusted padding for links within borders */
       transition: all 0.2s ease;

--- a/sections/hero-with-categories.liquid
+++ b/sections/hero-with-categories.liquid
@@ -15,6 +15,14 @@
                 <a href="{{ block.settings.link }}" class="category-link-hero">
                   {{ block.settings.title | downcase }}
                 </a>
+                {% assign subs = block.settings.subcategories | newline_to_br | split: '<br />' %}
+                {% if subs.size > 0 and subs[0] != '' %}
+                  <ul class="subcategory-list-hero">
+                    {% for sub in subs %}
+                      <li class="subcategory-item-hero">{{ sub }}</li>
+                    {% endfor %}
+                  </ul>
+                {% endif %}
               </li>
             {% endfor %}
           </ul>
@@ -109,6 +117,17 @@
       box-sizing: border-box;
       border-bottom: 1px solid #1e1e1e; /* Bottom border for each item */
     }
+    .subcategory-list-hero {
+      list-style: none;
+      margin: 0;
+      padding: 0 0 0 1.5rem;
+    }
+    .subcategory-item-hero {
+      font-size: clamp(1rem, 3vw, 1.5rem);
+      font-weight: 400;
+      line-height: 1.2;
+      padding: 0.25em 0;
+    }
     .category-link-hero {
       display: block;
       font-size: clamp(2rem, 6vw, 4.75rem); /* Responsive font size */
@@ -193,6 +212,12 @@
             "type": "image_picker",
             "id": "image",
             "label": "Category image"
+          },
+          {
+            "type": "textarea",
+            "id": "subcategories",
+            "label": "Subcategories (one per line)",
+            "info": "Optional list of subcategories"
           }
         ]
       }
@@ -201,10 +226,15 @@
       {
         "name": "Hero with Categories",
         "blocks": [
-          { "type": "category_link", "settings": { "title": "originals" }},
+          {
+            "type": "category_link",
+            "settings": {
+              "title": "originals",
+              "subcategories": "Figurative Art\nLandscapes\nStill Life\nUrban Art & Cities\nAnimal Art\nSurrealist Art\nAbstract Art"
+            }
+          },
           { "type": "category_link", "settings": { "title": "mixed media" }},
-          { "type": "category_link", "settings": { "title": "exhibitions" }},
-          { "type": "category_link", "settings": { "title": "faq" }},
+          { "type": "category_link", "settings": { "title": "prints" }}
         ]
       }
     ]

--- a/sections/info-bar.liquid
+++ b/sections/info-bar.liquid
@@ -33,10 +33,10 @@
   <div class="info-bar-col info-bar-right">
     <div class="info-bar-actions">
       <a href="/search" class="info-bar-action-link info-bar-search" aria-label="Search">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#1e1e1e" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-foreground, #000000)" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
       </a>
       <a href="{{ routes.cart_url }}" class="info-bar-action-link info-bar-cart" id="cart-icon-bubble">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#1e1e1e" stroke-width="1.5">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-foreground, #000000)" stroke-width="1.5">
           <circle cx="8" cy="21" r="1"/>
           <circle cx="19" cy="21" r="1"/>
           <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57L23 6H6"/>
@@ -57,10 +57,16 @@
   align-items: center; /* Align items to center vertically */
   width: 100%;
   padding: 1.5rem 2rem;
-  font-family: var(--main-font-stack);
-  font-size: 1.1rem; /* Smaller base font size for overall text */
-  background: #fff;
-  color: #111;
+  font-family: var(--font-primary--family, martianmono, sans-serif);
+  font-size: 12px;
+  line-height: 20px;
+  -webkit-font-kerning: normal;
+  font-kerning: normal;
+  text-rendering: optimizeLegibility;
+  -webkit-font-feature-settings: "onum" 1;
+  font-feature-settings: "onum" 1;
+  background: var(--color-background, #E6BDBE);
+  color: var(--color-foreground, #000000);
   box-sizing: border-box;
   gap: 2rem;
 }
@@ -89,7 +95,7 @@
 .info-bar-title {
   font-size: 2rem; /* Larger font size for main title */
   font-weight: 400;
-  color: #1e1e1e;
+  color: var(--color-foreground, #000000);
   text-decoration: none;
   letter-spacing: 0.04em;
   transition: opacity 0.3s ease;
@@ -106,7 +112,7 @@
   gap: 1.5rem;
 }
 .info-bar-action-link {
-  color: #1e1e1e; /* Darker color for icons */
+  color: var(--color-foreground, #000000); /* Match site text color */
   text-decoration: none;
   padding: 0.5rem;
   transition: all 0.3s ease;

--- a/sections/product.liquid
+++ b/sections/product.liquid
@@ -80,7 +80,7 @@
   align-items: flex-start;
   gap: 1.5rem;
   flex: 1 1 50%;
-  background: #fff;
+  background: var(--color-background, #E6BDBE);
   min-width: 0;
 }
 .product-main-image-leah {
@@ -106,7 +106,7 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  background: #fff;
+  background: var(--color-background, #E6BDBE);
   min-width: 0;
 }
 .product-title-leah {
@@ -296,10 +296,10 @@
   align-items: flex-start;
   width: 100%;
   padding: 1.5rem 2rem;
-  font-family: var(--main-font-stack);
+  font-family: var(--font-primary--family, martianmono, sans-serif);
   font-size: 2rem;
-  background: #fff;
-  color: #111;
+  background: var(--color-background, #E6BDBE);
+  color: var(--color-foreground, #000000);
   box-sizing: border-box;
   gap: 2rem;
 }

--- a/templates/index.json
+++ b/templates/index.json
@@ -17,7 +17,8 @@
           "settings": {
             "title": "originals",
             "link": "/collections/originals",
-            "image": "shopify://shop_images/Sky_Poetry_Painting.jpg"
+            "image": "shopify://shop_images/Sky_Poetry_Painting.jpg",
+            "subcategories": "Figurative Art\nLandscapes\nStill Life\nUrban Art & Cities\nAnimal Art\nSurrealist Art\nAbstract Art"
           }
         },
         "mixed-media": {
@@ -28,19 +29,11 @@
             "image": "shopify://shop_images/SavannahArtwork.jpg"
           }
         },
-        "exhibitions": {
+        "prints": {
           "type": "category_link",
           "settings": {
-            "title": "exhibitions",
-            "link": "/collections/exhibitions",
-            "image": "shopify://shop_images/THE_LAST_SUPPER_OF_THE_JOKER-1.jpg"
-          }
-        },
-        "faq": {
-          "type": "category_link",
-          "settings": {
-            "title": "faq",
-            "link": "/pages/faq",
+            "title": "prints",
+            "link": "/collections/prints",
             "image": "shopify://shop_images/Sun_on_the_Skillet_Painting.jpg"
           }
         }
@@ -48,8 +41,7 @@
       "block_order": [
         "originals",
         "mixed-media",
-        "exhibitions",
-        "faq"
+        "prints"
       ],
       "settings": {}
     },


### PR DESCRIPTION
## Summary
- support optional subcategories for hero categories
- update default hero categories to "Originals", "Mixed media" and "Prints"
- remove old categories from config data

## Testing
- `theme-check`

------
https://chatgpt.com/codex/tasks/task_e_684ff8e2fad883339a73f5ada8a26e76